### PR TITLE
Feat: Add translations

### DIFF
--- a/apps/records/models.py
+++ b/apps/records/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from django_ckeditor_5.fields import CKEditor5Field
 from django_countries.fields import CountryField
@@ -60,78 +61,118 @@ class RecordFormats:
 
 
 class Artist(models.Model):
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, verbose_name=_("Name"))
     discogs_id = models.IntegerField(unique=True, null=True, blank=True)
-    bio = CKEditor5Field(null=True, blank=True)
+    bio = CKEditor5Field(null=True, blank=True, verbose_name=_("Bio"))
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        verbose_name = _("Artist")
+        verbose_name_plural = _("Artists")
 
 
 class Label(models.Model):
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, verbose_name=_("Name"))
     discogs_id = models.IntegerField(unique=True, null=True, blank=True)
-    description = CKEditor5Field(null=True, blank=True)
+    description = CKEditor5Field(null=True, blank=True,
+                                 verbose_name=_("Description"))
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        verbose_name = _("Label")
+        verbose_name_plural = _("Labels")
 
 
 class Genre(models.Model):
-    name = models.CharField(max_length=100)
+    name = models.CharField(max_length=100, verbose_name=_("Name"))
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        verbose_name = _("Genre")
+        verbose_name_plural = _("Genres")
 
 
 class Style(models.Model):
-    name = models.CharField(max_length=100)
+    name = models.CharField(max_length=100, verbose_name=_("Name"))
 
     def __str__(self):
         return self.name
 
+    class Meta:
+        verbose_name = _("Style")
+        verbose_name_plural = _("Styles")
+
 
 class Record(models.Model):
-    title = models.CharField(max_length=255)
-    artists = models.ManyToManyField(Artist, related_name='records')
-    label = models.ForeignKey(Label, on_delete=models.SET_NULL, null=True, blank=True, related_name='records')
-    release_date = models.DateField(null=True, blank=True)
-    genres = models.ManyToManyField(Genre, related_name='records')
-    styles = models.ManyToManyField(Style, related_name='records')
+    title = models.CharField(max_length=255, verbose_name=_("Record title"))
+    artists = models.ManyToManyField(Artist, related_name='records',
+                                     verbose_name=_("Artist"))
+    label = models.ForeignKey(Label, on_delete=models.SET_NULL, null=True,
+                              blank=True, related_name='records',
+                              verbose_name=_("Label"))
+    release_date = models.DateField(null=True, blank=True,
+                                    verbose_name=_("Release date"))
+    genres = models.ManyToManyField(Genre, related_name='records',
+                                    verbose_name=_("Genre"))
+    styles = models.ManyToManyField(Style, related_name='records',
+                                    verbose_name=_("Style"))
     discogs_id = models.IntegerField(unique=True, null=True, blank=True)
     cover_image = ImageField(
         upload_to='images/',
         null=True,
-        blank=True
+        blank=True,
+        verbose_name=_("Record image"),
     )
-    notes = CKEditor5Field(null=True, blank=True)
+    notes = CKEditor5Field(null=True, blank=True, verbose_name=_("Notes"))
     stock = models.PositiveIntegerField(
         default=0,
-        verbose_name='Количество на складе'
+        verbose_name=_("Storage on hand"),
     )
     condition = models.CharField(
         max_length=3,
         choices=RecordConditions.CONDITION_CHOICES,
         default=RecordConditions.NM,
+        verbose_name=_("Condition"),
     )
-    catalog_number = models.CharField(max_length=50, unique=True, null=True, blank=True)
-    barcode = models.CharField(max_length=20, unique=True, null=True, blank=True)
+    catalog_number = models.CharField(max_length=50, unique=True,
+                                      null=True, blank=True,
+                                      verbose_name=_("Catalog number"))
+    barcode = models.CharField(max_length=20, unique=True,
+                               null=True, blank=True,
+                               verbose_name=_("Barcode"))
     format = models.CharField(
         max_length=7,
         choices=RecordFormats.FORMAT_CHOICES,
         default=RecordFormats.OTHER,
+        verbose_name=_("Format"),
     )
-    country = CountryField(null=True, blank=True)
+    country = CountryField(null=True, blank=True, verbose_name=_("Country"))
 
     def __str__(self):
         return self.title
 
+    class Meta:
+        verbose_name = _("Record")
+        verbose_name_plural = _("Records")
+
 
 class Track(models.Model):
-    record = models.ForeignKey(Record, on_delete=models.CASCADE, related_name='tracks')
+    record = models.ForeignKey(Record, on_delete=models.CASCADE,
+                               related_name='tracks')
     position = models.CharField(max_length=10)
-    title = models.CharField(max_length=255)
-    duration = models.CharField(max_length=10, null=True, blank=True)
+    title = models.CharField(max_length=255, verbose_name=_("Track title"))
+    duration = models.CharField(max_length=10, null=True,
+                                blank=True, verbose_name=_("Duration"))
 
     def __str__(self):
         return f"{self.position}. {self.title}"
+
+    class Meta:
+        verbose_name = _("Track")
+        verbose_name_plural = _("Tracks")

--- a/config/settings.py
+++ b/config/settings.py
@@ -59,6 +59,9 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # Third party middleware
+    'django.middleware.locale.LocaleMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -116,11 +119,18 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
+
+LANGUAGES = [
+    ('en', 'English'),
+    ('ru', 'Russian'),
+]
 
 TIME_ZONE = 'UTC'
 
 USE_I18N = True
+
+USE_L10N = True
 
 USE_TZ = True
 
@@ -138,6 +148,11 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # CKEditor5
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+# Translations
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale'),
+]
 
 customColorPalette = [
     {

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,128 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-04 14:37+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps/records/models.py:64 apps/records/models.py:77
+#: apps/records/models.py:91 apps/records/models.py:102
+msgid "Name"
+msgstr ""
+
+#: apps/records/models.py:66
+msgid "Bio"
+msgstr ""
+
+#: apps/records/models.py:72 apps/records/models.py:115
+msgid "Artist"
+msgstr ""
+
+#: apps/records/models.py:73
+msgid "Artists"
+msgstr ""
+
+#: apps/records/models.py:80
+msgid "Description"
+msgstr ""
+
+#: apps/records/models.py:86 apps/records/models.py:118
+msgid "Label"
+msgstr ""
+
+#: apps/records/models.py:87
+msgid "Labels"
+msgstr ""
+
+#: apps/records/models.py:97 apps/records/models.py:122
+msgid "Genre"
+msgstr ""
+
+#: apps/records/models.py:98
+msgid "Genres"
+msgstr ""
+
+#: apps/records/models.py:108 apps/records/models.py:124
+msgid "Style"
+msgstr ""
+
+#: apps/records/models.py:109
+msgid "Styles"
+msgstr ""
+
+#: apps/records/models.py:113
+msgid "Record title"
+msgstr ""
+
+#: apps/records/models.py:120
+msgid "Release date"
+msgstr ""
+
+#: apps/records/models.py:130
+msgid "Record image"
+msgstr ""
+
+#: apps/records/models.py:132
+msgid "Notes"
+msgstr ""
+
+#: apps/records/models.py:135
+msgid "Storage on hand"
+msgstr ""
+
+#: apps/records/models.py:141
+msgid "Condition"
+msgstr ""
+
+#: apps/records/models.py:145
+msgid "Catalog number"
+msgstr ""
+
+#: apps/records/models.py:148
+msgid "Barcode"
+msgstr ""
+
+#: apps/records/models.py:153
+msgid "Format"
+msgstr ""
+
+#: apps/records/models.py:155
+msgid "Country"
+msgstr ""
+
+#: apps/records/models.py:161
+msgid "Record"
+msgstr ""
+
+#: apps/records/models.py:162
+msgid "Records"
+msgstr ""
+
+#: apps/records/models.py:169
+msgid "Track title"
+msgstr ""
+
+#: apps/records/models.py:171
+msgid "Duration"
+msgstr ""
+
+#: apps/records/models.py:177
+msgid "Track"
+msgstr ""
+
+#: apps/records/models.py:178
+msgid "Tracks"
+msgstr ""

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,130 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-04 14:36+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: apps/records/models.py:64 apps/records/models.py:77
+#: apps/records/models.py:91 apps/records/models.py:102
+msgid "Name"
+msgstr "Название"
+
+#: apps/records/models.py:66
+msgid "Bio"
+msgstr "Биография"
+
+#: apps/records/models.py:72 apps/records/models.py:115
+msgid "Artist"
+msgstr "Исполнитель"
+
+#: apps/records/models.py:73
+msgid "Artists"
+msgstr "Исполнители"
+
+#: apps/records/models.py:80
+msgid "Description"
+msgstr "Описание"
+
+#: apps/records/models.py:86 apps/records/models.py:118
+msgid "Label"
+msgstr "Лейбл"
+
+#: apps/records/models.py:87
+msgid "Labels"
+msgstr "Лейблы"
+
+#: apps/records/models.py:97 apps/records/models.py:122
+msgid "Genre"
+msgstr "Жанр"
+
+#: apps/records/models.py:98
+msgid "Genres"
+msgstr "Жанры"
+
+#: apps/records/models.py:108 apps/records/models.py:124
+msgid "Style"
+msgstr "Стиль"
+
+#: apps/records/models.py:109
+msgid "Styles"
+msgstr "Стили"
+
+#: apps/records/models.py:113
+msgid "Record title"
+msgstr "Название пластинки"
+
+#: apps/records/models.py:120
+msgid "Release date"
+msgstr "Дата релиза"
+
+#: apps/records/models.py:130
+msgid "Record image"
+msgstr "Изображение пластинки"
+
+#: apps/records/models.py:132
+msgid "Notes"
+msgstr "Примечание"
+
+#: apps/records/models.py:135
+msgid "Storage on hand"
+msgstr "Количество на складе"
+
+#: apps/records/models.py:141
+msgid "Condition"
+msgstr "Состояние"
+
+#: apps/records/models.py:145
+msgid "Catalog number"
+msgstr "Номер в каталоге"
+
+#: apps/records/models.py:148
+msgid "Barcode"
+msgstr "Штрих-код"
+
+#: apps/records/models.py:153
+msgid "Format"
+msgstr "Формат"
+
+#: apps/records/models.py:155
+msgid "Country"
+msgstr "Страна"
+
+#: apps/records/models.py:161
+msgid "Record"
+msgstr "Пластинка"
+
+#: apps/records/models.py:162
+msgid "Records"
+msgstr "Пластинки"
+
+#: apps/records/models.py:169
+msgid "Track title"
+msgstr "Название трека"
+
+#: apps/records/models.py:171
+msgid "Duration"
+msgstr "Продолжительность"
+
+#: apps/records/models.py:177
+msgid "Track"
+msgstr "Трек"
+
+#: apps/records/models.py:178
+msgid "Tracks"
+msgstr "Треки"


### PR DESCRIPTION
[Указать везде gettext_lazy в моделях #5](https://github.com/khoshov/dubplate-special/issues/5)
[Добавить в models класс Meta #7](https://github.com/khoshov/dubplate-special/issues/7)

У нас в .gitignore прописаны .mo файлы на 57 строке, нужно будет компилить переводы каждый раз вручную:

django-admin compilemessages