### PR TITLE
Follow-up: недостающие изменения после merge #107

### DIFF
--- a/apps/records/admin/actions.py
+++ b/apps/records/admin/actions.py
@@ -105,7 +105,9 @@ def _batch_update(
         )
     if fail:
         if show_fail_summary:
-            admin_obj.message_user(request, fail_msg.format(n=fail), level=messages.ERROR)
+            admin_obj.message_user(
+                request, fail_msg.format(n=fail), level=messages.ERROR
+            )
         failed_lines_html = format_html_join(
             "",
             "<br>&nbsp;&nbsp;&bull; {}",

--- a/apps/records/admin/inlines.py
+++ b/apps/records/admin/inlines.py
@@ -68,7 +68,9 @@ class StructuredFormatInlineForm(forms.ModelForm):
         quantity = cleaned.get("quantity")
 
         # Полностью пустая строка считается очищенной и не создаёт новый вариант.
-        is_effectively_empty = not any((carrier, format_name, details)) and quantity in (
+        is_effectively_empty = not any(
+            (carrier, format_name, details)
+        ) and quantity in (
             None,
             1,
         )
@@ -100,7 +102,9 @@ class StructuredFormatInlineFormSet(BaseInlineFormSet):
             if self.can_delete and self._should_delete_form(form):
                 continue
 
-            variant_of_format = getattr(form.instance, "variant_of_format", None) or index
+            variant_of_format = (
+                getattr(form.instance, "variant_of_format", None) or index
+            )
             if variant_of_format != active_variant:
                 continue
 
@@ -115,7 +119,9 @@ class StructuredFormatInlineFormSet(BaseInlineFormSet):
             return
 
     def _selected_variant_of_format(self) -> int | None:
-        raw_variant = str(self.data.get("active_structured_format_variant") or "").strip()
+        raw_variant = str(
+            self.data.get("active_structured_format_variant") or ""
+        ).strip()
         if raw_variant.isdigit():
             selected_variant = int(raw_variant)
             if selected_variant > 0:

--- a/apps/records/forms/record_form.py
+++ b/apps/records/forms/record_form.py
@@ -121,9 +121,9 @@ class RecordForm(ApplyFieldsMixin, forms.ModelForm):
             self.fields.pop("source_url", None)
             if "active_structured_format_variant" in self.fields:
                 self.fields["active_structured_format_variant"].required = False
-                self.fields["active_structured_format_variant"].widget = (
-                    forms.HiddenInput()
-                )
+                self.fields[
+                    "active_structured_format_variant"
+                ].widget = forms.HiddenInput()
 
     def _setup_fields_for_new_record(self, _current_source: str) -> None:
         """Убирает поля, не участвующие в импорте при создании записи."""

--- a/apps/records/forms/validators.py
+++ b/apps/records/forms/validators.py
@@ -117,6 +117,7 @@ class RecordIdentifierValidator:
         Raises:
             ValidationError: Если не указан ни один идентификатор.
         """
+
         def _has_value(key: str) -> bool:
             value = cleaned_data.get(key)
             if value not in (None, ""):

--- a/apps/records/services/providers/redeye/redeye_service.py
+++ b/apps/records/services/providers/redeye/redeye_service.py
@@ -125,7 +125,9 @@ class RedeyeService:
             href = (link.get("href", "") or "").strip()
             if not href:
                 continue
-            abs_url = href if href.startswith("http") else urljoin(REDEYE_BASE_URL, href)
+            abs_url = (
+                href if href.startswith("http") else urljoin(REDEYE_BASE_URL, href)
+            )
             abs_url = normalize_abs_url(abs_url)
             if abs_url in seen:
                 continue

--- a/tests/admin/test_action.py
+++ b/tests/admin/test_action.py
@@ -135,16 +135,12 @@ def test_update_from_redeye_action_shows_error_when_exact_match_not_found(monkey
 
     all_messages = html.unescape("\n".join(msg for msg, _ in admin.messages))
     assert "С ошибками: 1." not in all_messages
-    assert (
-        "Обновление записи с id #"
-        in all_messages
-    )
+    assert "Обновление записи с id #" in all_messages
     assert "«R1» из Redeye невозможно" in all_messages
     assert "на сайте не найден релиз с каталожным номером 'SP34'" in all_messages
     assert exception_calls == []
     assert any(
-        "Ожидаемая ошибка при обновлении" in str(args[0])
-        for args, _ in info_calls
+        "Ожидаемая ошибка при обновлении" in str(args[0]) for args, _ in info_calls
     )
 
 

--- a/tests/admin/test_record_admin_structured_formats.py
+++ b/tests/admin/test_record_admin_structured_formats.py
@@ -156,7 +156,9 @@ def test_record_format_inline_formset_allows_clearing_existing_row() -> None:
 
 
 @pytest.mark.django_db
-def test_record_format_inline_formset_assigns_variant_of_format_to_first_manual_row() -> None:
+def test_record_format_inline_formset_assigns_variant_of_format_to_first_manual_row() -> (
+    None
+):
     admin_user = _make_superuser()
     record = Record.objects.create(title="Manual structured row")
 
@@ -339,13 +341,17 @@ def test_change_page_preserves_selected_variant_after_save(client) -> None:
     record.refresh_from_db()
     assert record.active_structured_format_variant == 2
 
-    reload_response = client.get(reverse("admin:records_record_change", args=[record.pk]))
+    reload_response = client.get(
+        reverse("admin:records_record_change", args=[record.pk])
+    )
     assert reload_response.status_code == 200
     assert 'value="2"' in reload_response.content.decode("utf-8")
 
 
 @pytest.mark.django_db
-def test_change_page_shows_error_for_incomplete_active_structured_format(client) -> None:
+def test_change_page_shows_error_for_incomplete_active_structured_format(
+    client,
+) -> None:
     admin_user = _make_superuser()
     client.force_login(admin_user)
     record = Record.objects.create(

--- a/tests/test_record_form_discogs.py
+++ b/tests/test_record_form_discogs.py
@@ -72,11 +72,14 @@ class RecordFormDiscogsDuplicateFieldTests(TestCase):
 
         assert not form.is_valid()
         assert "discogs_id" in form.errors
-        assert "Укажите Discogs ID в формате 1724093 или [r1724093]." in form.errors[
-            "discogs_id"
-        ][0]
+        assert (
+            "Укажите Discogs ID в формате 1724093 или [r1724093]."
+            in form.errors["discogs_id"][0]
+        )
 
-    def test_duplicate_catalog_number_does_not_add_identifiers_required_error(self) -> None:
+    def test_duplicate_catalog_number_does_not_add_identifiers_required_error(
+        self,
+    ) -> None:
         Record.objects.create(title="Bleach", catalog_number="SP34")
 
         form = RecordForm(

--- a/tests/test_redeye_service.py
+++ b/tests/test_redeye_service.py
@@ -29,8 +29,7 @@ def test_fetch_by_catalog_number_uses_exact_match_from_candidates():
     http = DummyHTTPClient(
         {
             search_url: (
-                '<a href="/vinyl/111-first">One</a>'
-                '<a href="/vinyl/222-second">Two</a>'
+                '<a href="/vinyl/111-first">One</a><a href="/vinyl/222-second">Two</a>'
             ),
             first_url: "<html></html>",
             second_url: "<html></html>",


### PR DESCRIPTION
## Что это за PR
Follow-up к уже смерженному PR #107.

После merge в `vk_post` остался недостающий пакет изменений (commit `5cc0d5d`), который не вошёл в предыдущий merge.

## Что входит
- Доработки в admin/forms/redeye service и тестах (всего 9 файлов):
  - `apps/records/admin/actions.py`
  - `apps/records/admin/inlines.py`
  - `apps/records/forms/record_form.py`
  - `apps/records/forms/validators.py`
  - `apps/records/services/providers/redeye/redeye_service.py`
  - `tests/admin/test_action.py`
  - `tests/admin/test_record_admin_structured_formats.py`
  - `tests/test_record_form_discogs.py`
  - `tests/test_redeye_service.py`

## Объём
- `+38 / -23`
- `9 files changed`

## Контекст
- Предыдущий PR: #107
- Этот PR добавляет только фактический diff между `fix/discogs-import-contract` и текущим `vk_post`.
